### PR TITLE
Fix#109 - Image and Leaf IDs Download for Firefox

### DIFF
--- a/src/Branch.js
+++ b/src/Branch.js
@@ -701,13 +701,11 @@ export default class Branch {
 
   downloadLeafIdsFromBranch() {
     var downloadData = this.getChildIds().join('\n');
-    var filename = "pc_leaf_ids";
+    var filename = 'pc_leaf_ids';
     if (!this.parent) {
-      // If root
-      filename += "_all.txt";
-    }
-    else {
-      filename += "_" + this.id + ".txt";
+      filename += '_all.txt';
+    } else {
+      filename += '_' + this.id + '.txt';
     }
     return createBlobUrl(downloadData);
   }

--- a/src/Branch.js
+++ b/src/Branch.js
@@ -701,7 +701,15 @@ export default class Branch {
 
   downloadLeafIdsFromBranch() {
     var downloadData = this.getChildIds().join('\n');
-    setupDownloadLink(createBlobUrl(downloadData), 'pc_leaves.txt');
+    var filename = "pc_leaf_ids";
+    if (!this.parent) {
+      // If root
+      filename += "_all.txt";
+    }
+    else {
+      filename += "_" + this.id + ".txt";
+    }
+    setupDownloadLink(createBlobUrl(downloadData), filename);
   }
 
   setDisplay({ colour, shape, size }) {

--- a/src/Branch.js
+++ b/src/Branch.js
@@ -1,5 +1,5 @@
 import { Angles } from './utils/constants';
-import { setupDownloadLink, createBlobUrl } from './utils/dom';
+import { createBlobUrl } from './utils/dom';
 
 import nodeRenderers from './nodeRenderers';
 
@@ -709,7 +709,7 @@ export default class Branch {
     else {
       filename += "_" + this.id + ".txt";
     }
-    setupDownloadLink(createBlobUrl(downloadData), filename);
+    return createBlobUrl(downloadData);
   }
 
   setDisplay({ colour, shape, size }) {

--- a/src/ContextMenu.js
+++ b/src/ContextMenu.js
@@ -1,3 +1,4 @@
+
 import Tooltip from './Tooltip';
 import { createHandler, preventDefault } from './utils/events';
 
@@ -16,13 +17,13 @@ function createImageLink(contextMenu) {
 }
 
 function createLeafIdsLink(contextMenu) {
-  let leafdata = contextMenu.tree.root.downloadLeafIdsFromBranch()
-  let anchorElement = createAnchorElement(contextMenu, { text: this.text , filename: 'pc-leaf-ids-root.txt', href: leafdata });
+  let leafdata = contextMenu.tree.root.downloadLeafIdsFromBranch();
+  let anchorElement = createAnchorElement(contextMenu, { text: this.text, filename: 'pc-leaf-ids-root.txt', href: leafdata });
   return anchorElement;
 }
 
 function createBranchLeafIdsLink(contextMenu, node) {
-  let leafdata = node.downloadLeafIdsFromBranch()
+  let leafdata = node.downloadLeafIdsFromBranch();
   let anchorElement = createAnchorElement(contextMenu, { text: this.text, filename: `pc-leaf-ids-${node.id}.txt`, href: leafdata });
   return anchorElement;
 }
@@ -84,7 +85,7 @@ function mouseout(element) {
 }
 
 function transferMenuItem({ handler, text = 'New menu Item', nodeType, element }) {
-  return { handler, text, nodeType, element};
+  return { handler, text, nodeType, element };
 }
 
 /**
@@ -118,17 +119,16 @@ export default class ContextMenu extends Tooltip {
         continue;
       }
 
-      if(menuItem.element) {
+      if (menuItem.element) {
         let anchorElement = menuItem.element(this, node);
         listElement = this.createElement('li', anchorElement);
-      }
-      else {
+      } else {
         listElement = this.createElement('li', menuItem.text);
       }
 
       listElement.style.listStyle = 'none outside none';
 
-      if(!menuItem.element) {
+      if (!menuItem.element) {
         if (menuItem.nodeType) {
           listElement.addEventListener(
             'click', createHandler(node, menuItem.handler)
@@ -154,6 +154,3 @@ export default class ContextMenu extends Tooltip {
     this.element.appendChild(list);
   }
 }
-
-
-

--- a/src/ContextMenu.js
+++ b/src/ContextMenu.js
@@ -1,6 +1,32 @@
 import Tooltip from './Tooltip';
 import { createHandler, preventDefault } from './utils/events';
 
+function createAnchorElement(contextMenu, { text='link', filename='file', href }) {
+  let anchorElement = contextMenu.createElement('a', text);
+  anchorElement.style.padding = '0px';
+  anchorElement.href = href;
+  anchorElement.style.textDecoration = 'none';
+  anchorElement.download = filename;
+  return anchorElement;
+}
+
+function createImageLink(contextMenu) {
+  let anchorElement = createAnchorElement(contextMenu, { text: this.text, filename: 'phylocanvas_tree.png', href: contextMenu.tree.getPngUrl() });
+  return anchorElement;
+}
+
+function createLeafIdsLink(contextMenu) {
+  let leafdata = contextMenu.tree.root.downloadLeafIdsFromBranch()
+  let anchorElement = createAnchorElement(contextMenu, { text: this.text , filename: 'pc-leaf-ids-root.txt', href: leafdata });
+  return anchorElement;
+}
+
+function createBranchLeafIdsLink(contextMenu, node) {
+  let leafdata = node.downloadLeafIdsFromBranch()
+  let anchorElement = createAnchorElement(contextMenu, { text: this.text, filename: `pc-leaf-ids-${node.id}.txt`, href: leafdata });
+  return anchorElement;
+}
+
 const DEFAULT_MENU_ITEMS = [
   { text: 'Collapse/Expand Branch',
     handler: function (branch) {
@@ -21,16 +47,17 @@ const DEFAULT_MENU_ITEMS = [
     handler: 'toggleLabels'
   }, {
     text: 'Export As Image',
-    handler: 'exportCurrentTreeView'
+    element: createImageLink
   }, {
     text: 'Export Leaf IDs',
-    handler: 'downloadAllLeafIds'
+    element: createLeafIdsLink
   }, {
     text: 'Export Leaf IDs on Branch',
-    handler: 'downloadLeafIdsFromBranch',
+    element: createBranchLeafIdsLink,
     nodeType: 'internal'
   }
 ];
+
 
 function menuItemApplicable(menuItem, node) {
   if (!node) {
@@ -49,15 +76,15 @@ function menuItemApplicable(menuItem, node) {
 }
 
 function mouseover(element) {
-  element.style.backgroundColor = '#E2E3DF';
+  element.style.backgroundColor = '#d2d2c4';
 }
 
 function mouseout(element) {
   element.style.backgroundColor = 'transparent';
 }
 
-function transferMenuItem({ handler, text = 'New menu Item', nodeType }) {
-  return { handler, text, nodeType };
+function transferMenuItem({ handler, text = 'New menu Item', nodeType, element }) {
+  return { handler, text, nodeType, element};
 }
 
 /**
@@ -82,7 +109,7 @@ export default class ContextMenu extends Tooltip {
 
   createContent(node) {
     let list = document.createElement('ul');
-
+    let listElement;
     list.style.margin = '0';
     list.style.padding = '0';
 
@@ -91,17 +118,26 @@ export default class ContextMenu extends Tooltip {
         continue;
       }
 
-      let listElement = this.createElement('li', menuItem.text);
+      if(menuItem.element) {
+        let anchorElement = menuItem.element(this, node);
+        listElement = this.createElement('li', anchorElement);
+      }
+      else {
+        listElement = this.createElement('li', menuItem.text);
+      }
+
       listElement.style.listStyle = 'none outside none';
 
-      if (menuItem.nodeType) {
-        listElement.addEventListener(
-          'click', createHandler(node, menuItem.handler)
-        );
-      } else {
-        listElement.addEventListener(
-          'click', createHandler(this.tree, menuItem.handler)
-        );
+      if(!menuItem.element) {
+        if (menuItem.nodeType) {
+          listElement.addEventListener(
+            'click', createHandler(node, menuItem.handler)
+          );
+        } else {
+          listElement.addEventListener(
+            'click', createHandler(this.tree, menuItem.handler)
+          );
+        }
       }
       listElement.addEventListener('click', this.click);
       listElement.addEventListener('contextmenu', preventDefault);
@@ -117,5 +153,7 @@ export default class ContextMenu extends Tooltip {
     document.body.addEventListener('click', createHandler(this, 'close'));
     this.element.appendChild(list);
   }
-
 }
+
+
+

--- a/src/Tooltip.js
+++ b/src/Tooltip.js
@@ -31,7 +31,13 @@ export default class Tooltip {
     element.style.padding = '0.3em 0.5em 0.3em 0.5em';
     element.style.fontFamily = this.tree.font;
     element.style.fontSize = this.fontSize || '12pt';
-    element.appendChild(document.createTextNode(textContent));
+    element.style.color = 'black';
+    if (typeof textContent === 'object') {
+      element.appendChild(textContent);
+    }
+    else {
+      element.appendChild(document.createTextNode(textContent));
+    }
     return element;
   }
 
@@ -56,7 +62,6 @@ export default class Tooltip {
 
     this.element.style.zIndex = 2000;
     this.element.style.display = 'block';
-    this.element.style.backgroundColor = '#FFFFFF';
 
     this.closed = false;
   }

--- a/src/Tooltip.js
+++ b/src/Tooltip.js
@@ -34,8 +34,7 @@ export default class Tooltip {
     element.style.color = 'black';
     if (typeof textContent === 'object') {
       element.appendChild(textContent);
-    }
-    else {
+    } else {
       element.appendChild(document.createTextNode(textContent));
     }
     return element;

--- a/src/Tree.js
+++ b/src/Tree.js
@@ -5,7 +5,7 @@ import Navigator from './Navigator';
 
 import treeTypes from './treeTypes';
 
-import { addClass, setupDownloadLink } from './utils/dom';
+import { addClass } from './utils/dom';
 import { fireEvent, addEvent } from './utils/events';
 import { getBackingStorePixelRatio, getPixelRatio, translateClick } from './utils/canvas';
 import parsers from './parsers';
@@ -836,15 +836,6 @@ export default class Tree {
     this.draw();
     this.history.resizeTree();
   }
-
-  downloadAllLeafIds() {
-    this.root.downloadLeafIdsFromBranch();
-  }
-
-  exportCurrentTreeView() {
-    setupDownloadLink(this.getPngUrl(), 'phylocanvas.png');
-  }
-
 }
 
 Tree.prototype.on = Tree.prototype.addListener;

--- a/src/utils/dom.js
+++ b/src/utils/dom.js
@@ -14,7 +14,7 @@ export function setupDownloadLink(url, filename) {
   anchor.href = url;
   anchor.target = '_blank';
   if (isDownloadSupported) {
-    anchor.download = filename;
+    anchor.download = (filename)?filename:'pc_download';
   }
 
   // dispatch for firefox + others
@@ -24,7 +24,11 @@ export function setupDownloadLink(url, filename) {
 
   // fireEvent(anchor, 'click');
   if (isDownloadSupported) {
-    windowURL.revokeObjectURL(anchor.href);
+    setTimeout(function(){
+      document.body.removeChild(anchor);
+      windowURL.revokeObjectURL(anchor.href);
+    }, 100);
+
   }
 }
 

--- a/src/utils/dom.js
+++ b/src/utils/dom.js
@@ -16,7 +16,13 @@ export function setupDownloadLink(url, filename) {
   if (isDownloadSupported) {
     anchor.download = filename;
   }
-  fireEvent(anchor, 'click');
+
+  // dispatch for firefox + others
+  var evObj = document.createEvent('MouseEvent');
+  evObj.initEvent('click', true, true);
+  anchor.dispatchEvent(evObj);
+
+  // fireEvent(anchor, 'click');
   if (isDownloadSupported) {
     windowURL.revokeObjectURL(anchor.href);
   }

--- a/src/utils/dom.js
+++ b/src/utils/dom.js
@@ -1,5 +1,3 @@
-import { fireEvent } from './events';
-
 let windowURL = window.URL || window.webkitURL;
 
 export function createBlobUrl(data) {
@@ -7,28 +5,27 @@ export function createBlobUrl(data) {
   return windowURL.createObjectURL(blob);
 }
 
-export function setupDownloadLink(url, filename) {
+export function setupDownloadLink(url, filename = 'pc_download') {
   var anchor = document.createElement('a');
   var isDownloadSupported = (typeof anchor.download !== 'undefined');
 
   anchor.href = url;
   anchor.target = '_blank';
   if (isDownloadSupported) {
-    anchor.download = (filename)?filename:'pc_download';
+    anchor.download = filename;
   }
 
   // dispatch for firefox + others
-  var evObj = document.createEvent('MouseEvent');
+  const evObj = document.createEvent('MouseEvent');
   evObj.initEvent('click', true, true);
   anchor.dispatchEvent(evObj);
 
   // fireEvent(anchor, 'click');
   if (isDownloadSupported) {
-    setTimeout(function(){
+    setTimeout(function () {
       document.body.removeChild(anchor);
       windowURL.revokeObjectURL(anchor.href);
     }, 100);
-
   }
 }
 


### PR DESCRIPTION
**Image Fix:**
  * HTMLEvents was not working for this particular case in firefox. Replaced with MouseEvent.

**LeafID Export Fix:**
  * revokeObjectURL() executed by the time it initiated the download

