### PR TITLE
fixes webpack Module build failed

### DIFF
--- a/src/Branch.js
+++ b/src/Branch.js
@@ -197,7 +197,7 @@ export default class Branch {
    * used for auto ids for internal nodes
    * @static
    */
-  static lastId = 0
+  static lastId = 0;
 
   static generateId() {
     return 'pcn' + this.lastId++;


### PR DESCRIPTION
Fixed a webpack error from commit 8849ce3 which, after a fresh `npm install`, still produced the following errors:
> ERROR in ./Branch.js
> Module build failed: SyntaxError: /Users/jh22/git/PhyloCanvas/src/Branch.js: A semicolon is required after a class property (200:19)


*the bundle has not been built in this PR* (it would probably be identical anyway)