### PR TITLE
Metakey drag

### DIFF
--- a/dev/index.js
+++ b/dev/index.js
@@ -138,6 +138,8 @@ function () {
     },
   });
 
+  tree.shiftKeyDrag = true;
+
   // tree.updateLeaves(tree.findLeaves('(A|B)'), 'highlighted', true);
 
   // tree.branches.A.radius = 2;

--- a/src/Tree.js
+++ b/src/Tree.js
@@ -6,7 +6,7 @@ import { ChildNodesTooltip as Tooltip } from './Tooltip';
 import treeTypes from './treeTypes';
 import parsers from './parsers';
 
-const { addClass } = dom;
+const { addClass, setCursorDrag, setCursorDragging } = dom;
 const { fireEvent, addEvent } = events;
 const { getPixelRatio, translateClick } = canvas;
 
@@ -431,6 +431,11 @@ class Tree {
      */
     this.farthestNodeFromRootY = 0;
 
+    /**
+     * Require the 'shift' key to be depressed to allow dragging
+     */
+    this.shiftKeyDrag = false;
+
 
     /**
      * Maximum length of label for each tree type.
@@ -594,6 +599,7 @@ class Tree {
         this.offsety = this.origy + ymove;
         this.draw();
       }
+      setCursorDragging(this.containerElement);
     } else {
       // hover
       const e = event;
@@ -610,7 +616,11 @@ class Tree {
       } else {
         this.tooltip.close();
         this.root.cascadeFlag('hovered', false);
-        this.containerElement.style.cursor = 'auto';
+        if (this.shiftKeyDrag && e.shiftKey) {
+          setCursorDrag(this.containerElement);
+        } else {
+          this.containerElement.style.cursor = 'auto';
+        }
       }
       this.draw();
     }
@@ -661,16 +671,18 @@ class Tree {
    * @param {MouseEvent} event
    */
   pickup(event) {
-    if (!this.drawn) return false;
-    this.origx = this.offsetx;
-    this.origy = this.offsety;
+    if (!this.shiftKeyDrag || event.shiftKey) {
+      if (!this.drawn) return false;
+      this.origx = this.offsetx;
+      this.origy = this.offsety;
 
-    if (event.button === 0) {
-      this.pickedup = true;
+      if (event.button === 0) {
+        this.pickedup = true;
+      }
+
+      this.startx = event.clientX;
+      this.starty = event.clientY;
     }
-
-    this.startx = event.clientX;
-    this.starty = event.clientY;
   }
 
   /**

--- a/src/utils/dom.js
+++ b/src/utils/dom.js
@@ -76,3 +76,23 @@ export function hasClass(element, className) {
 
   return index !== -1;
 }
+
+/**
+ * Setting the cursor to dragging required vendor prefixes.
+ * @param domElement
+ */
+export function setCursorDragging(domElement) {
+  domElement.style.cursor = "-webkit-grabbing";
+  domElement.style.cursor = "-moz-grabbing";
+  domElement.style.cursor = "grabbing";
+}
+
+/**
+ * Setting the cursor to drag required vendor prefixes.
+ * @param domElement
+ */
+export function setCursorDrag(domElement) {
+  domElement.style.cursor = "-webkit-grab";
+  domElement.style.cursor = "-moz-grab";
+  domElement.style.cursor = "grab";
+}


### PR DESCRIPTION
Hi Guys,

Don't know if this pull request is of interest to you or not.  What it does is to allow the developer to set a flag `tree.shiftKeyDrag = true;` forcing the use of the <kbd>Shift</kbd> key to drag the canvas around, similar to how photoshop using the <kbd>spacebar</kbd>.

The reasoning for this is I want to work on plugins that when the user `mousedown`s I can draw shapes to the canvas, in particular the grouping selection that we discussed.

Please let me know what you think,
Josh