### PR TITLE
Toggle displaying branch lengths that have a value of '0'

### DIFF
--- a/dev/index.js
+++ b/dev/index.js
@@ -80,6 +80,17 @@ zoomCheckbox.addEventListener('change', (e) => {
 zoomLabel.appendChild(zoomCheckbox);
 document.body.appendChild(zoomLabel);
 
+const hideZerosLABEL = document.createElement('label');
+hideZerosLABEL.appendChild(document.createTextNode('Hide Branch Length Zeros'));
+const hideZerosCheckbox = document.createElement('input');
+hideZerosCheckbox.type = 'checkbox';
+hideZerosCheckbox.addEventListener('change', (e) => {
+  tree.hideBranchLengthZeros = e.target.checked;
+  tree.draw();
+});
+hideZerosLABEL.appendChild(hideZerosCheckbox);
+document.body.appendChild(hideZerosLABEL);
+
 
 tree.on('error', function (event) { throw event.error; });
 

--- a/src/Branch.js
+++ b/src/Branch.js
@@ -300,7 +300,8 @@ class Branch {
   }
 
   /**
-   * The canvas {@link https://developer.mozilla.org/en/docs/Web/API/CanvasRenderingContext2D drawing context} of the parent tree.
+   * The canvas {@link https://developer.mozilla.org/en/docs/Web/API/CanvasRenderingContext2D drawing context} of the
+   * parent tree.
    *
    * @type CanvasRenderingContext2D
    */
@@ -491,6 +492,19 @@ class Branch {
    * @method
    */
   drawBranchLabels() {
+    /**
+     * Test to see if the Branch Length Label should be drawn on the {@lin Branch}
+     * @method
+     * @returns {boolean}
+     */
+    function shouldDrawBranchLengthLabel() {
+      if (this.tree.showBranchLengthLabels) {
+        if (this.tree.hideBranchLengthZeros) {
+          return this.branchLength > 0;
+        }
+        return true;
+      }
+    }
     this.canvas.save();
     const labelStyle = this.internalLabelStyle || this.tree.internalLabelStyle;
     this.canvas.fillStyle = labelStyle.colour;
@@ -507,7 +521,7 @@ class Branch {
       this.centery :
       (this.starty + this.centery) / 2;
 
-    if (this.tree.showBranchLengthLabels) {
+    if (shouldDrawBranchLengthLabel.call(this)) {
       this.canvas.fillText(this.branchLength.toFixed(2), x, y + em);
     }
 

--- a/src/Tree.js
+++ b/src/Tree.js
@@ -372,6 +372,16 @@ class Tree {
      * @default
      */
     this.showBranchLengthLabels = false;
+
+    /**
+     * If displaying {@link this.showBranchLengthLabels}, this can be set to true to hide branch length that have a '0'
+     * value
+     *
+     * @type {boolean}
+     * @default
+     */
+    this.hideBranchLengthZeros = false;
+
     /**
      * @type boolean
      * @default


### PR DESCRIPTION
This is a feature that our user base has been asking for.  A lot of there trees have many values with branch lengths === 0.  What they want is the ability to hide all of these values.  Currently they are exporting their trees into illustrator and manually deleting all of them (seriously time consuming on large trees!).